### PR TITLE
chore: migrate releases to Tagsmith

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,11 +6,38 @@ on:
       - 'v*'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
+  validate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      target: ${{ steps.tagsmith.outputs.target }}
+      channel: ${{ steps.tagsmith.outputs.channel }}
+      strategy: ${{ steps.tagsmith.outputs.strategy }}
+      version: ${{ steps.tagsmith.outputs.version }}
+      base-version: ${{ steps.tagsmith.outputs.baseVersion }}
+      tag: ${{ steps.tagsmith.outputs.tag }}
+      tag-message: ${{ steps.tagsmith.outputs.tagMessage }}
+      commit: ${{ steps.tagsmith.outputs.commit }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch tags and remote branches
+        run: git fetch --force --tags origin '+refs/heads/*:refs/remotes/origin/*'
+
+      - name: Validate release tag
+        id: tagsmith
+        run: npx tagsmith@latest validate --tag "$GITHUB_REF_NAME" --github-output
+
   build:
     name: Build
+    needs: validate
     runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
@@ -32,8 +59,10 @@ jobs:
             name: linux-arm64
             runner: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout validated commit
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.validate.outputs.commit }}
 
       - name: Setup Go
         uses: actions/setup-go@v5
@@ -44,8 +73,8 @@ jobs:
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          VERSION=${GITHUB_REF_NAME#v}
           go build -ldflags "-X main.version=${VERSION}" -o mdp ./cmd/mdp
 
       - name: Create archive
@@ -60,17 +89,20 @@ jobs:
 
   release:
     name: Release
-    needs: build
+    needs: [validate, build]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       sha256_darwin_amd64: ${{ steps.sha256.outputs.darwin_amd64 }}
       sha256_darwin_arm64: ${{ steps.sha256.outputs.darwin_arm64 }}
       sha256_linux_amd64: ${{ steps.sha256.outputs.linux_amd64 }}
       sha256_linux_arm64: ${{ steps.sha256.outputs.linux_arm64 }}
     steps:
-      - name: Checkout
+      - name: Checkout validated commit
         uses: actions/checkout@v4
         with:
+          ref: ${{ needs.validate.outputs.commit }}
           fetch-depth: 0
 
       - name: Download artifacts
@@ -100,12 +132,14 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.validate.outputs.tag }}
+          target_commitish: ${{ needs.validate.outputs.commit }}
           files: artifacts/*.tar.gz
           body: ${{ steps.changelog.outputs.content }}
 
   update-homebrew:
     name: Update Homebrew Tap
-    needs: release
+    needs: [validate, release]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout homebrew-tap
@@ -117,7 +151,7 @@ jobs:
 
       - name: Update formula
         env:
-          VERSION: ${{ github.ref_name }}
+          VERSION: ${{ needs.validate.outputs.tag }}
           SHA256_AMD64: ${{ needs.release.outputs.sha256_darwin_amd64 }}
           SHA256_ARM64: ${{ needs.release.outputs.sha256_darwin_arm64 }}
         run: |
@@ -155,7 +189,7 @@ jobs:
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
           git add Formula/mdp.rb
-          git commit -m "release: mdp version ${{ github.ref_name }}
+          git commit -m "release: mdp version ${{ needs.validate.outputs.tag }}
 
-          Release: https://github.com/sadiksaifi/mdp/releases/tag/${{ github.ref_name }}"
+          Release: https://github.com/sadiksaifi/mdp/releases/tag/${{ needs.validate.outputs.tag }}"
           git push

--- a/.tagsmith.jsonc
+++ b/.tagsmith.jsonc
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://tagsmith.sadiksaifi.dev/schema/v1.json",
+  "configVersion": 1,
+
+  "git": {
+    "remote": "origin",
+    "baseBranch": "main",
+  },
+
+  "defaults": {
+    "tagPattern": "v{version}",
+    "tagMessage": "Release v{version}",
+    "initialVersion": "3.2.0",
+  },
+
+  "targets": {
+    "mdp": {
+      "path": ".",
+      "channels": [{ "name": "stable", "strategy": "stable" }],
+    },
+  },
+}

--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ assets/               # CSS assets
 | `make release` | Build for all platforms |
 | `make clean` | Remove build artifacts |
 
+### Releases
+
+Releases are managed by [Tagsmith](https://tagsmith.sadiksaifi.dev/) using the repo's `.tagsmith.jsonc` config.
+
+```bash
+npx tagsmith@latest targets
+npx tagsmith@latest tag --channel stable --bump patch --dry-run --json
+npx tagsmith@latest tag --channel stable --bump patch --push
+```
+
+Tagsmith-created annotated `v*` tags are validated in CI before release artifacts and the Homebrew tap update are published.
+
 ### Running Tests
 
 ```bash

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestIsNewerVersion(t *testing.T) {
@@ -221,5 +222,5 @@ func TestCheckForUpdateWithContext_UsesCachedState(t *testing.T) {
 
 // jsonTime returns current time in JSON format for test fixtures
 func jsonTime() string {
-	return `2026-01-15T10:00:00Z` // Recent time that's within 24h
+	return time.Now().UTC().Format(time.RFC3339)
 }


### PR DESCRIPTION
## Summary
- add Tagsmith config for the existing v{version} release tag namespace with v3.2.0 as the adoption boundary
- add a release-tag validation gate before build/release/Homebrew publishing
- document the Tagsmith release workflow and fix the updater cache test fixture so tests remain time-independent

## Test Plan
- npx tagsmith@latest targets --json
- make test
- make build
- git diff --check