### PR TITLE
feat: add Windows installation and self-upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,45 @@ jobs:
 
       - name: Verify binary
         run: ./mdp --version
+
+  windows-distribution:
+    name: Windows distribution
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build Windows AMD64
+        env:
+          GOOS: windows
+          GOARCH: amd64
+        run: go build -o mdp-windows-amd64.exe ./cmd/mdp
+
+      - name: Build Windows ARM64
+        env:
+          GOOS: windows
+          GOARCH: arm64
+        run: go build -o mdp-windows-arm64.exe ./cmd/mdp
+
+      - name: Test Windows release archives
+        run: go test ./internal/updater -run 'TestReleaseAssetFor|TestExtract|TestWindowsReplacement'
+
+      - name: Validate PowerShell installer syntax
+        shell: pwsh
+        run: |
+          $tokens = $null
+          $errors = $null
+          [void][System.Management.Automation.Language.Parser]::ParseFile(
+            (Resolve-Path scripts/install.ps1),
+            [ref]$tokens,
+            [ref]$errors
+          )
+          if ($errors.Count -gt 0) {
+            $errors | ForEach-Object { Write-Error $_ }
+            exit 1
+          }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,7 @@ jobs:
             $errors | ForEach-Object { Write-Error $_ }
             exit 1
           }
+
+      - name: Test PowerShell installer architecture selection
+        shell: pwsh
+        run: ./scripts/install_test.ps1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,18 +46,38 @@ jobs:
             goarch: amd64
             name: darwin-amd64
             runner: macos-latest
+            binary: mdp
+            archive: tar.gz
           - goos: darwin
             goarch: arm64
             name: darwin-arm64
             runner: macos-latest
+            binary: mdp
+            archive: tar.gz
           - goos: linux
             goarch: amd64
             name: linux-amd64
             runner: ubuntu-latest
+            binary: mdp
+            archive: tar.gz
           - goos: linux
             goarch: arm64
             name: linux-arm64
             runner: ubuntu-latest
+            binary: mdp
+            archive: tar.gz
+          - goos: windows
+            goarch: amd64
+            name: windows-amd64
+            runner: ubuntu-latest
+            binary: mdp.exe
+            archive: zip
+          - goos: windows
+            goarch: arm64
+            name: windows-arm64
+            runner: ubuntu-latest
+            binary: mdp.exe
+            archive: zip
     steps:
       - name: Checkout validated commit
         uses: actions/checkout@v4
@@ -75,17 +95,21 @@ jobs:
           GOARCH: ${{ matrix.goarch }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
-          go build -ldflags "-X main.version=${VERSION}" -o mdp ./cmd/mdp
+          go build -ldflags "-X main.version=${VERSION}" -o ${{ matrix.binary }} ./cmd/mdp
 
       - name: Create archive
         run: |
-          tar -czvf mdp-${{ matrix.name }}.tar.gz mdp
+          if [ "${{ matrix.archive }}" = "zip" ]; then
+            zip mdp-${{ matrix.name }}.zip ${{ matrix.binary }}
+          else
+            tar -czvf mdp-${{ matrix.name }}.tar.gz ${{ matrix.binary }}
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: mdp-${{ matrix.name }}
-          path: mdp-${{ matrix.name }}.tar.gz
+          path: mdp-${{ matrix.name }}.${{ matrix.archive }}
 
   release:
     name: Release
@@ -134,7 +158,9 @@ jobs:
         with:
           tag_name: ${{ needs.validate.outputs.tag }}
           target_commitish: ${{ needs.validate.outputs.commit }}
-          files: artifacts/*.tar.gz
+          files: |
+            artifacts/*.tar.gz
+            artifacts/*.zip
           body: ${{ steps.changelog.outputs.content }}
 
   update-homebrew:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,17 +52,18 @@ internal/
 assets/               # Original CSS file (also embedded in template package)
 scripts/              # Installation scripts
   install.sh          # Curl-based installer for macOS/Linux
+  install.ps1         # PowerShell installer for Windows
 ```
 
-**Single-file flow**: Read .md file → Convert to HTML via goldmark (GFM) → Generate HTML document with embedded GitHub CSS → Write to `/tmp/mdpreview-{filename}.html` → Open in browser
+**Single-file flow**: Read .md file → Convert to HTML via goldmark (GFM) → Generate HTML document with embedded GitHub CSS → Write to the system temporary directory as `mdpreview-{filename}.html` → Open in browser
 
-**Multi-file flow**: Resolve files (expand directories, respect .gitignore) → Convert all to HTML → Build file tree structure → Generate HTML with sidebar navigation → Write to `/tmp/mdpreview-multi.html` → Open in browser
+**Multi-file flow**: Resolve files (expand directories, respect .gitignore) → Convert all to HTML → Build file tree structure → Generate HTML with sidebar navigation → Write to the system temporary directory as `mdpreview-multi.html` → Open in browser
 
-**Export flow (--output/-O)**: Same as single/multi-file flow, but writes to user-specified path instead of `/tmp/` and skips browser opening
+**Export flow (--output/-O)**: Same as single/multi-file flow, but writes to the user-specified path and skips browser opening
 
 **Live reload flow (--serve)**: Resolve files → Start HTTP server → Watch files with fsnotify → On change: re-convert markdown → Notify clients via WebSocket → Browser auto-refreshes
 
-**Upgrade flow (mdp upgrade)**: Detect install method (brew/curl/source) → If brew: show upgrade instructions → If curl: fetch latest release from GitHub API → Download binary → Replace in place → Update state file
+**Upgrade flow (mdp upgrade)**: Detect install method (brew/curl/source) → If brew: show upgrade instructions → If curl, PowerShell, or unknown: fetch the matching release archive from GitHub → Extract the binary → Replace it in place. Windows runs the downloaded binary as a short-lived helper that waits for the original process to exit before replacing `mdp.exe`.
 
 **Auto-update check**: On each `mdp` run → Check if 24h since last check → Query GitHub API (2s timeout, non-blocking) → Cache result → Show notification if update available
 
@@ -72,8 +73,8 @@ scripts/              # Installation scripts
 - Syntax highlighting uses goldmark-highlighting with Chroma (200+ languages supported)
 - Chroma classes are mapped to GitHub's PrettyLights CSS variables for consistent theming
 - Code blocks have a copy button (appears on hover) for easy clipboard copying
-- Single file output: `/tmp/mdpreview-{filename}.html`
-- Multi-file output: `/tmp/mdpreview-multi.html`
+- Single file output: `<system temp>/mdpreview-{filename}.html`
+- Multi-file output: `<system temp>/mdpreview-multi.html`
 - Live reload uses WebSocket for instant browser refresh on file changes
 - Cross-platform: supports macOS (`open`), Linux (`xdg-open`), and Windows (`rundll32`)
 - Directory scanning respects `.gitignore` files at all levels using `github.com/sabhiram/go-gitignore`

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ release: ## Build release binaries for multiple platforms
 	GOOS=darwin GOARCH=amd64 go build -o $(DIST_DIR)/$(BINARY)-darwin-amd64 $(CMD_DIR)
 	GOOS=darwin GOARCH=arm64 go build -o $(DIST_DIR)/$(BINARY)-darwin-arm64 $(CMD_DIR)
 	GOOS=linux GOARCH=amd64 go build -o $(DIST_DIR)/$(BINARY)-linux-amd64 $(CMD_DIR)
+	GOOS=linux GOARCH=arm64 go build -o $(DIST_DIR)/$(BINARY)-linux-arm64 $(CMD_DIR)
+	GOOS=windows GOARCH=amd64 go build -o $(DIST_DIR)/$(BINARY)-windows-amd64.exe $(CMD_DIR)
+	GOOS=windows GOARCH=arm64 go build -o $(DIST_DIR)/$(BINARY)-windows-arm64.exe $(CMD_DIR)
 	@echo "Release binaries built in $(DIST_DIR)/"
 
 clean: ## Remove built artifacts

--- a/README.md
+++ b/README.md
@@ -41,7 +41,15 @@ brew install sadiksaifi/tap/mdp
 curl -fsSL https://raw.githubusercontent.com/sadiksaifi/mdp/main/scripts/install.sh | sh
 ```
 
-This installs mdp to `~/.local/bin` and automatically configures your PATH.
+This installs `mdp` to `~/.local/bin` and automatically configures your PATH.
+
+### PowerShell (Windows)
+
+```powershell
+irm https://raw.githubusercontent.com/sadiksaifi/mdp/main/scripts/install.ps1 | iex
+```
+
+This installs `mdp.exe` to `%LOCALAPPDATA%\Programs\mdp`, and automatically configures your PATH.
 
 ### From Source
 
@@ -73,6 +81,14 @@ brew upgrade sadiksaifi/tap/mdp
 ```bash
 mdp upgrade
 ```
+
+### PowerShell Installation
+
+```powershell
+mdp upgrade
+```
+
+On Windows, mdp safely finishes replacing `mdp.exe` after the running upgrade process exits.
 
 mdp automatically checks for updates and notifies you when a new version is available.
 
@@ -154,8 +170,8 @@ mdp --serve --port 3000 ./docs/    # Start server on port 3000
 
 | Mode | Output |
 |------|--------|
-| **Single file** | Opens `/tmp/mdpreview-{filename}.html` in your default browser |
-| **Multiple files/directory** | Opens `/tmp/mdpreview-multi.html` with sidebar navigation |
+| **Single file** | Opens `mdpreview-{filename}.html` from your system temporary directory in your default browser |
+| **Multiple files/directory** | Opens `mdpreview-multi.html` from your system temporary directory with sidebar navigation |
 | **Export mode (`-O`)** | Writes HTML to specified file path |
 | **Live reload mode** | Starts HTTP server at `http://localhost:<port>` with WebSocket auto-refresh |
 

--- a/cmd/mdp/main.go
+++ b/cmd/mdp/main.go
@@ -24,6 +24,15 @@ import (
 var version = "dev"
 
 func main() {
+	handled, err := updater.RunUpgradeHelper()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Windows upgrade failed: %v\n", err)
+		os.Exit(1)
+	}
+	if handled {
+		return
+	}
+
 	if err := run(os.Args[1:]); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
@@ -239,7 +248,7 @@ func isIgnored(path, baseDir string, matchers map[string]*gitignore.GitIgnore) b
 }
 
 // runSingleFile handles single file preview (original behavior).
-// If outputPath is provided, writes to that path instead of /tmp and skips browser.
+// If outputPath is provided, writes to that path instead of the system temporary directory and skips browser.
 func runSingleFile(filePath string, outputPath string) error {
 	markdownContent, err := os.ReadFile(filePath)
 	if err != nil {
@@ -261,7 +270,7 @@ func runSingleFile(filePath string, outputPath string) error {
 	openBrowser := false
 	if outputPath == "" {
 		outputFileName := fmt.Sprintf("mdpreview-%s.html", strings.ReplaceAll(filename, ".md", ""))
-		outputPath = filepath.Join("/tmp", outputFileName)
+		outputPath = filepath.Join(os.TempDir(), outputFileName)
 		openBrowser = true
 	}
 
@@ -281,7 +290,7 @@ func runSingleFile(filePath string, outputPath string) error {
 }
 
 // runMultiFile handles multiple files preview with sidebar.
-// If outputPath is provided, writes to that path instead of /tmp and skips browser.
+// If outputPath is provided, writes to that path instead of the system temporary directory and skips browser.
 func runMultiFile(filePaths []string, outputPath string) error {
 	conv := converter.New()
 
@@ -325,7 +334,7 @@ func runMultiFile(filePaths []string, outputPath string) error {
 	// Determine output path
 	openBrowser := false
 	if outputPath == "" {
-		outputPath = filepath.Join("/tmp", "mdpreview-multi.html")
+		outputPath = filepath.Join(os.TempDir(), "mdpreview-multi.html")
 		openBrowser = true
 	}
 

--- a/cmd/mdp/main_test.go
+++ b/cmd/mdp/main_test.go
@@ -94,7 +94,7 @@ func TestRun_ValidMarkdownFile(t *testing.T) {
 	}
 
 	// Verify output file was created
-	outputPath := filepath.Join("/tmp", "mdpreview-test.html")
+	outputPath := filepath.Join(os.TempDir(), "mdpreview-test.html")
 	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		t.Error("expected output file to be created")
 	}
@@ -169,7 +169,7 @@ func TestRun_MultipleFiles(t *testing.T) {
 	}
 
 	// Verify output file was created
-	outputPath := filepath.Join("/tmp", "mdpreview-multi.html")
+	outputPath := filepath.Join(os.TempDir(), "mdpreview-multi.html")
 	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		t.Error("expected output file to be created")
 	}
@@ -229,7 +229,7 @@ func TestRun_Directory(t *testing.T) {
 	}
 
 	// Verify output content contains both files
-	outputPath := filepath.Join("/tmp", "mdpreview-multi.html")
+	outputPath := filepath.Join(os.TempDir(), "mdpreview-multi.html")
 	outputContent, err := os.ReadFile(outputPath)
 	if err != nil {
 		t.Fatalf("failed to read output file: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/yuin/goldmark v1.7.13
 	github.com/yuin/goldmark-highlighting/v2 v2.0.0-20230729083705-37449abec8cc
 	golang.org/x/mod v0.32.0
+	golang.org/x/sys v0.13.0
 )
 
 require (
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	golang.org/x/net v0.17.0 // indirect
-	golang.org/x/sys v0.13.0 // indirect
 )

--- a/internal/updater/archive.go
+++ b/internal/updater/archive.go
@@ -1,0 +1,187 @@
+package updater
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const maxReleaseBinarySize = 128 << 20 // 128 MiB
+
+type releaseAsset struct {
+	archiveName string
+	binaryName  string
+	format      string
+}
+
+func releaseAssetFor(goos, goarch string) (releaseAsset, error) {
+	if goarch != "amd64" && goarch != "arm64" {
+		return releaseAsset{}, fmt.Errorf("unsupported architecture: %s", goarch)
+	}
+
+	switch goos {
+	case "darwin", "linux":
+		return releaseAsset{
+			archiveName: fmt.Sprintf("mdp-%s-%s.tar.gz", goos, goarch),
+			binaryName:  "mdp",
+			format:      "tar.gz",
+		}, nil
+	case "windows":
+		return releaseAsset{
+			archiveName: fmt.Sprintf("mdp-windows-%s.zip", goarch),
+			binaryName:  "mdp.exe",
+			format:      "zip",
+		}, nil
+	default:
+		return releaseAsset{}, fmt.Errorf("unsupported operating system: %s", goos)
+	}
+}
+
+func extractReleaseBinary(archivePath, destDir string, asset releaseAsset) error {
+	switch asset.format {
+	case "tar.gz":
+		return extractTarGz(archivePath, destDir, asset.binaryName)
+	case "zip":
+		return extractZip(archivePath, destDir, asset.binaryName)
+	default:
+		return fmt.Errorf("unsupported archive format: %s", asset.format)
+	}
+}
+
+func extractTarGz(archivePath, destDir, expectedName string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = file.Close() }()
+
+	gzr, err := gzip.NewReader(file)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = gzr.Close() }()
+
+	tr := tar.NewReader(gzr)
+	found := false
+	for {
+		header, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return err
+		}
+		if err := validateArchivePath(header.Name); err != nil {
+			return err
+		}
+		if header.Name != expectedName {
+			continue
+		}
+		if found {
+			return fmt.Errorf("archive contains duplicate %s", expectedName)
+		}
+		if header.Typeflag != tar.TypeReg && header.Typeflag != 0 {
+			return fmt.Errorf("archive entry %s is not a regular file", expectedName)
+		}
+		if header.Size < 0 || header.Size > maxReleaseBinarySize {
+			return fmt.Errorf("archive entry %s is too large", expectedName)
+		}
+
+		if err := writeReleaseBinary(filepath.Join(destDir, expectedName), tr, os.FileMode(header.Mode)); err != nil {
+			return err
+		}
+		found = true
+	}
+
+	if !found {
+		return fmt.Errorf("archive does not contain %s", expectedName)
+	}
+	return nil
+}
+
+func extractZip(archivePath, destDir, expectedName string) error {
+	zr, err := zip.OpenReader(archivePath)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = zr.Close() }()
+
+	found := false
+	for _, entry := range zr.File {
+		if err := validateArchivePath(entry.Name); err != nil {
+			return err
+		}
+		if entry.Name != expectedName {
+			continue
+		}
+		if found {
+			return fmt.Errorf("archive contains duplicate %s", expectedName)
+		}
+		if !entry.FileInfo().Mode().IsRegular() {
+			return fmt.Errorf("archive entry %s is not a regular file", expectedName)
+		}
+		if entry.UncompressedSize64 > maxReleaseBinarySize {
+			return fmt.Errorf("archive entry %s is too large", expectedName)
+		}
+
+		src, err := entry.Open()
+		if err != nil {
+			return err
+		}
+		writeErr := writeReleaseBinary(filepath.Join(destDir, expectedName), src, 0755)
+		closeErr := src.Close()
+		if writeErr != nil {
+			return writeErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+		found = true
+	}
+
+	if !found {
+		return fmt.Errorf("archive does not contain %s", expectedName)
+	}
+	return nil
+}
+
+func validateArchivePath(name string) error {
+	cleaned := path.Clean(name)
+	if name == "" || strings.HasPrefix(name, "/") || strings.Contains(name, "\\") ||
+		strings.Contains(name, ":") || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return fmt.Errorf("archive contains invalid path: %s", name)
+	}
+	return nil
+}
+
+func writeReleaseBinary(target string, src io.Reader, mode os.FileMode) error {
+	if mode.Perm() == 0 {
+		mode = 0755
+	}
+	out, err := os.OpenFile(target, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode.Perm())
+	if err != nil {
+		return err
+	}
+
+	written, copyErr := io.Copy(out, io.LimitReader(src, maxReleaseBinarySize+1))
+	closeErr := out.Close()
+	if copyErr != nil {
+		_ = os.Remove(target)
+		return copyErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(target)
+		return closeErr
+	}
+	if written > maxReleaseBinarySize {
+		_ = os.Remove(target)
+		return fmt.Errorf("release binary is too large")
+	}
+	return nil
+}

--- a/internal/updater/archive_test.go
+++ b/internal/updater/archive_test.go
@@ -1,0 +1,175 @@
+package updater
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReleaseAssetFor(t *testing.T) {
+	tests := []struct {
+		name        string
+		goos        string
+		goarch      string
+		archiveName string
+		binaryName  string
+		format      string
+		wantErr     bool
+	}{
+		{name: "macOS AMD64", goos: "darwin", goarch: "amd64", archiveName: "mdp-darwin-amd64.tar.gz", binaryName: "mdp", format: "tar.gz"},
+		{name: "macOS ARM64", goos: "darwin", goarch: "arm64", archiveName: "mdp-darwin-arm64.tar.gz", binaryName: "mdp", format: "tar.gz"},
+		{name: "Linux AMD64", goos: "linux", goarch: "amd64", archiveName: "mdp-linux-amd64.tar.gz", binaryName: "mdp", format: "tar.gz"},
+		{name: "Linux ARM64", goos: "linux", goarch: "arm64", archiveName: "mdp-linux-arm64.tar.gz", binaryName: "mdp", format: "tar.gz"},
+		{name: "Windows AMD64", goos: "windows", goarch: "amd64", archiveName: "mdp-windows-amd64.zip", binaryName: "mdp.exe", format: "zip"},
+		{name: "Windows ARM64", goos: "windows", goarch: "arm64", archiveName: "mdp-windows-arm64.zip", binaryName: "mdp.exe", format: "zip"},
+		{name: "unsupported OS", goos: "freebsd", goarch: "amd64", wantErr: true},
+		{name: "unsupported architecture", goos: "windows", goarch: "386", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			asset, err := releaseAssetFor(tt.goos, tt.goarch)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("releaseAssetFor() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("releaseAssetFor() error = %v", err)
+			}
+			if asset.archiveName != tt.archiveName || asset.binaryName != tt.binaryName || asset.format != tt.format {
+				t.Errorf("releaseAssetFor() = %+v, want archive=%q binary=%q format=%q", asset, tt.archiveName, tt.binaryName, tt.format)
+			}
+		})
+	}
+}
+
+func TestExtractReleaseBinary(t *testing.T) {
+	const content = "mdp test binary"
+	tests := []struct {
+		name   string
+		asset  releaseAsset
+		create func(*testing.T, string, []archiveTestEntry)
+	}{
+		{
+			name:   "tar.gz",
+			asset:  releaseAsset{binaryName: "mdp", format: "tar.gz"},
+			create: createTarGz,
+		},
+		{
+			name:   "zip",
+			asset:  releaseAsset{binaryName: "mdp.exe", format: "zip"},
+			create: createZip,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			archivePath := filepath.Join(tmpDir, "release.archive")
+			tt.create(t, archivePath, []archiveTestEntry{{name: tt.asset.binaryName, content: content}})
+
+			destDir := filepath.Join(tmpDir, "extract")
+			if err := os.Mkdir(destDir, 0755); err != nil {
+				t.Fatal(err)
+			}
+			if err := extractReleaseBinary(archivePath, destDir, tt.asset); err != nil {
+				t.Fatalf("extractReleaseBinary() error = %v", err)
+			}
+
+			got, err := os.ReadFile(filepath.Join(destDir, tt.asset.binaryName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(got) != content {
+				t.Errorf("extracted content = %q, want %q", got, content)
+			}
+		})
+	}
+}
+
+func TestExtractZipRejectsUnsafeOrInvalidArchives(t *testing.T) {
+	tests := []struct {
+		name    string
+		entries []archiveTestEntry
+	}{
+		{name: "missing binary", entries: []archiveTestEntry{{name: "README.txt", content: "missing"}}},
+		{name: "duplicate binary", entries: []archiveTestEntry{{name: "mdp.exe", content: "one"}, {name: "mdp.exe", content: "two"}}},
+		{name: "path traversal", entries: []archiveTestEntry{{name: "../mdp.exe", content: "unsafe"}}},
+		{name: "Windows absolute path", entries: []archiveTestEntry{{name: `C:\mdp.exe`, content: "unsafe"}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			archivePath := filepath.Join(tmpDir, "release.zip")
+			createZip(t, archivePath, tt.entries)
+
+			err := extractZip(archivePath, tmpDir, "mdp.exe")
+			if err == nil {
+				t.Fatal("extractZip() error = nil, want error")
+			}
+		})
+	}
+}
+
+type archiveTestEntry struct {
+	name    string
+	content string
+}
+
+func createZip(t *testing.T, archivePath string, entries []archiveTestEntry) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	zw := zip.NewWriter(file)
+	for _, entry := range entries {
+		writer, err := zw.Create(entry.name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := writer.Write([]byte(entry.content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func createTarGz(t *testing.T, archivePath string, entries []archiveTestEntry) {
+	t.Helper()
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gz := gzip.NewWriter(file)
+	tw := tar.NewWriter(gz)
+	for _, entry := range entries {
+		header := &tar.Header{Name: entry.name, Mode: 0755, Size: int64(len(entry.content)), Typeflag: tar.TypeReg}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(entry.content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/updater/replace_other.go
+++ b/internal/updater/replace_other.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package updater
+
+import "os"
+
+// RunUpgradeHelper reports whether this process is a deferred upgrade helper.
+// Deferred replacement is only required on Windows.
+func RunUpgradeHelper() (bool, error) {
+	return false, nil
+}
+
+func replaceBinary(src, dst, _ string) (bool, error) {
+	srcData, err := os.ReadFile(src)
+	if err != nil {
+		return false, err
+	}
+
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		return false, err
+	}
+
+	if err := os.Rename(src, dst); err == nil {
+		return false, nil
+	}
+
+	return false, os.WriteFile(dst, srcData, dstInfo.Mode())
+}

--- a/internal/updater/replace_windows.go
+++ b/internal/updater/replace_windows.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unsafe"
 
 	"golang.org/x/sys/windows"
 )
@@ -71,6 +72,14 @@ func RunUpgradeHelper() (bool, error) {
 }
 
 func replaceBinary(src, dst, version string) (bool, error) {
+	otherPID, err := findOtherRunningExecutable(dst)
+	if err != nil {
+		return false, fmt.Errorf("check for running mdp processes: %w", err)
+	}
+	if otherPID != 0 {
+		return false, fmt.Errorf("another mdp process (PID %d) is using %s; stop it and retry", otherPID, dst)
+	}
+
 	stagePath := dst + ".update.exe"
 	if err := os.Remove(stagePath); err != nil && !os.IsNotExist(err) {
 		return false, fmt.Errorf("remove stale upgrade helper: %w", err)
@@ -96,6 +105,64 @@ func replaceBinary(src, dst, version string) (bool, error) {
 		return false, fmt.Errorf("release Windows upgrade helper: %w", err)
 	}
 	return true, nil
+}
+
+func findOtherRunningExecutable(target string) (uint32, error) {
+	target, err := filepath.Abs(target)
+	if err != nil {
+		return 0, fmt.Errorf("resolve executable path: %w", err)
+	}
+
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return 0, fmt.Errorf("list Windows processes: %w", err)
+	}
+	defer windows.CloseHandle(snapshot)
+
+	var entry windows.ProcessEntry32
+	entry.Size = uint32(unsafe.Sizeof(entry))
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return 0, fmt.Errorf("read Windows process list: %w", err)
+	}
+
+	currentPID := uint32(os.Getpid())
+	for {
+		if entry.ProcessID != currentPID {
+			processPath, ok := processExecutablePath(entry.ProcessID)
+			if ok && equalWindowsPaths(processPath, target) {
+				return entry.ProcessID, nil
+			}
+		}
+
+		err = windows.Process32Next(snapshot, &entry)
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			return 0, nil
+		}
+		if err != nil {
+			return 0, fmt.Errorf("read Windows process list: %w", err)
+		}
+	}
+}
+
+func processExecutablePath(pid uint32) (string, bool) {
+	handle, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return "", false
+	}
+	defer windows.CloseHandle(handle)
+
+	buffer := make([]uint16, 32768)
+	size := uint32(len(buffer))
+	if err := windows.QueryFullProcessImageName(handle, 0, &buffer[0], &size); err != nil {
+		return "", false
+	}
+	return windows.UTF16ToString(buffer[:size]), true
+}
+
+func equalWindowsPaths(left, right string) bool {
+	left = strings.TrimPrefix(filepath.Clean(left), `\\?\`)
+	right = strings.TrimPrefix(filepath.Clean(right), `\\?\`)
+	return strings.EqualFold(left, right)
 }
 
 func waitForProcessExit(pid uint32, timeout time.Duration) error {

--- a/internal/updater/replace_windows.go
+++ b/internal/updater/replace_windows.go
@@ -1,0 +1,207 @@
+//go:build windows
+
+package updater
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	upgradeHelperEnv    = "MDP_UPGRADE_HELPER"
+	upgradeParentPIDEnv = "MDP_UPGRADE_PARENT_PID"
+	upgradeTargetEnv    = "MDP_UPGRADE_TARGET"
+	upgradeVersionEnv   = "MDP_UPGRADE_VERSION"
+)
+
+// RunUpgradeHelper completes a deferred Windows executable replacement.
+// Windows locks a running .exe, so the downloaded mdp binary waits for the
+// original process to exit before installing itself.
+func RunUpgradeHelper() (bool, error) {
+	if os.Getenv(upgradeHelperEnv) != "1" {
+		cleanupStaleUpgradeFiles()
+		return false, nil
+	}
+
+	parentPID, err := strconv.ParseUint(os.Getenv(upgradeParentPIDEnv), 10, 32)
+	if err != nil {
+		return true, fmt.Errorf("invalid upgrade parent PID: %w", err)
+	}
+	target := filepath.Clean(os.Getenv(upgradeTargetEnv))
+	version := os.Getenv(upgradeVersionEnv)
+	if target == "." || version == "" {
+		return true, fmt.Errorf("incomplete Windows upgrade helper configuration")
+	}
+
+	helperPath, err := os.Executable()
+	if err != nil {
+		return true, fmt.Errorf("find upgrade helper executable: %w", err)
+	}
+	helperPath, err = filepath.Abs(helperPath)
+	if err != nil {
+		return true, fmt.Errorf("resolve upgrade helper path: %w", err)
+	}
+	target, err = filepath.Abs(target)
+	if err != nil {
+		return true, fmt.Errorf("resolve upgrade target path: %w", err)
+	}
+	if !strings.EqualFold(filepath.Clean(helperPath), target+".update.exe") {
+		return true, fmt.Errorf("invalid Windows upgrade helper path")
+	}
+
+	if err := waitForProcessExit(uint32(parentPID), 30*time.Second); err != nil {
+		return true, err
+	}
+	if err := installWindowsReplacement(helperPath, target); err != nil {
+		return true, err
+	}
+
+	updateInstalledVersion(version)
+	fmt.Printf("Successfully upgraded to mdp %s\n", version)
+	return true, nil
+}
+
+func replaceBinary(src, dst, version string) (bool, error) {
+	stagePath := dst + ".update.exe"
+	if err := os.Remove(stagePath); err != nil && !os.IsNotExist(err) {
+		return false, fmt.Errorf("remove stale upgrade helper: %w", err)
+	}
+	if err := copyExecutable(src, stagePath, 0755); err != nil {
+		return false, fmt.Errorf("stage Windows upgrade helper: %w", err)
+	}
+
+	cmd := exec.Command(stagePath)
+	cmd.Env = append(os.Environ(),
+		upgradeHelperEnv+"=1",
+		upgradeParentPIDEnv+"="+strconv.Itoa(os.Getpid()),
+		upgradeTargetEnv+"="+dst,
+		upgradeVersionEnv+"="+version,
+	)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		_ = os.Remove(stagePath)
+		return false, fmt.Errorf("start Windows upgrade helper: %w", err)
+	}
+	if err := cmd.Process.Release(); err != nil {
+		return false, fmt.Errorf("release Windows upgrade helper: %w", err)
+	}
+	return true, nil
+}
+
+func waitForProcessExit(pid uint32, timeout time.Duration) error {
+	handle, err := windows.OpenProcess(windows.SYNCHRONIZE, false, pid)
+	if errors.Is(err, windows.ERROR_INVALID_PARAMETER) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("open upgrade parent process: %w", err)
+	}
+	defer windows.CloseHandle(handle)
+
+	result, err := windows.WaitForSingleObject(handle, uint32(timeout/time.Millisecond))
+	if err != nil {
+		return fmt.Errorf("wait for upgrade parent process: %w", err)
+	}
+	if result == uint32(windows.WAIT_TIMEOUT) {
+		return fmt.Errorf("timed out waiting for the original mdp process to exit")
+	}
+	if result != uint32(windows.WAIT_OBJECT_0) {
+		return fmt.Errorf("unexpected wait result while upgrading: %d", result)
+	}
+	return nil
+}
+
+func installWindowsReplacement(helperPath, target string) error {
+	backupPath := target + ".old"
+	readyPath := target + ".new"
+	for _, stalePath := range []string{backupPath, readyPath} {
+		if err := os.Remove(stalePath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("remove stale upgrade file %s: %w", stalePath, err)
+		}
+	}
+
+	info, err := os.Stat(target)
+	if err != nil {
+		return fmt.Errorf("inspect current executable: %w", err)
+	}
+	if err := copyExecutable(helperPath, readyPath, info.Mode()); err != nil {
+		return fmt.Errorf("prepare replacement executable: %w", err)
+	}
+
+	var renameErr error
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		renameErr = os.Rename(target, backupPath)
+		if renameErr == nil || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if renameErr != nil {
+		_ = os.Remove(readyPath)
+		return fmt.Errorf("move current executable aside: %w", renameErr)
+	}
+
+	if err := os.Rename(readyPath, target); err != nil {
+		_ = os.Remove(readyPath)
+		restoreErr := os.Rename(backupPath, target)
+		if restoreErr != nil {
+			return fmt.Errorf("install replacement executable: %w (restore failed: %v; previous binary remains at %s)", err, restoreErr, backupPath)
+		}
+		return fmt.Errorf("install replacement executable: %w", err)
+	}
+
+	// Antivirus software can briefly retain the previous executable. A future
+	// mdp invocation also removes this backup, so cleanup failure is non-fatal.
+	_ = os.Remove(backupPath)
+	return nil
+}
+
+func copyExecutable(src, dst string, mode os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.OpenFile(dst, os.O_CREATE|os.O_EXCL|os.O_WRONLY, mode.Perm())
+	if err != nil {
+		return err
+	}
+	_, copyErr := io.Copy(out, in)
+	syncErr := out.Sync()
+	closeErr := out.Close()
+	if copyErr != nil {
+		_ = os.Remove(dst)
+		return copyErr
+	}
+	if syncErr != nil {
+		_ = os.Remove(dst)
+		return syncErr
+	}
+	if closeErr != nil {
+		_ = os.Remove(dst)
+		return closeErr
+	}
+	return nil
+}
+
+func cleanupStaleUpgradeFiles() {
+	target, err := os.Executable()
+	if err != nil {
+		return
+	}
+	for _, suffix := range []string{".update.exe", ".old", ".new"} {
+		_ = os.Remove(target + suffix)
+	}
+}

--- a/internal/updater/replace_windows_test.go
+++ b/internal/updater/replace_windows_test.go
@@ -3,10 +3,110 @@
 package updater
 
 import (
+	"bytes"
+	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
+
+func TestWindowsReplacementRejectsAnotherRunningInstance(t *testing.T) {
+	tmpDir := t.TempDir()
+	targetPath := filepath.Join(tmpDir, "mdp.exe")
+	copyRunningTestExecutable(t, targetPath)
+	startExecutableHolder(t, targetPath)
+
+	replacementPath := filepath.Join(tmpDir, "replacement.exe")
+	if err := os.WriteFile(replacementPath, []byte("replacement"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	deferred, err := replaceBinary(replacementPath, targetPath, "v1.2.3")
+	if err == nil {
+		t.Fatal("replaceBinary() error = nil, want another running process error")
+	}
+	if deferred {
+		t.Error("replaceBinary() deferred = true, want false")
+	}
+	if !strings.Contains(err.Error(), "another mdp process") {
+		t.Fatalf("replaceBinary() error = %q, want another mdp process error", err)
+	}
+}
+
+func TestWindowsReplacementProcessHolder(t *testing.T) {
+	if os.Getenv("MDP_TEST_EXECUTABLE_HOLDER") != "1" {
+		return
+	}
+
+	readyPath := os.Getenv("MDP_TEST_EXECUTABLE_HOLDER_READY")
+	if err := os.WriteFile(readyPath, []byte("ready"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := io.Copy(io.Discard, os.Stdin); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func copyRunningTestExecutable(t *testing.T, targetPath string) {
+	t.Helper()
+
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := copyExecutable(executable, targetPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func startExecutableHolder(t *testing.T, targetPath string) {
+	t.Helper()
+
+	readyPath := filepath.Join(t.TempDir(), "ready")
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	cmd := exec.Command(targetPath, "-test.run=^TestWindowsReplacementProcessHolder$")
+	cmd.Env = append(os.Environ(),
+		"MDP_TEST_EXECUTABLE_HOLDER=1",
+		"MDP_TEST_EXECUTABLE_HOLDER_READY="+readyPath,
+	)
+	cmd.Stdin = reader
+	cmd.Stdout = &output
+	cmd.Stderr = &output
+	if err := cmd.Start(); err != nil {
+		_ = reader.Close()
+		_ = writer.Close()
+		t.Fatal(err)
+	}
+	_ = reader.Close()
+
+	t.Cleanup(func() {
+		_ = writer.Close()
+		if err := cmd.Wait(); err != nil {
+			t.Errorf("executable holder failed: %v\n%s", err, output.String())
+		}
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(readyPath); err == nil {
+			return
+		} else if !os.IsNotExist(err) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for executable holder\n%s", output.String())
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
 
 func TestWindowsReplacementInstallsNewBinary(t *testing.T) {
 	tmpDir := t.TempDir()

--- a/internal/updater/replace_windows_test.go
+++ b/internal/updater/replace_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package updater
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestWindowsReplacementInstallsNewBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+	helperPath := filepath.Join(tmpDir, "mdp.exe.update.exe")
+	targetPath := filepath.Join(tmpDir, "mdp.exe")
+
+	if err := os.WriteFile(helperPath, []byte("new binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, []byte("old binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installWindowsReplacement(helperPath, targetPath); err != nil {
+		t.Fatalf("installWindowsReplacement() error = %v", err)
+	}
+
+	got, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new binary" {
+		t.Errorf("installed binary = %q, want %q", got, "new binary")
+	}
+	if _, err := os.Stat(targetPath + ".old"); !os.IsNotExist(err) {
+		t.Errorf("backup file still exists, stat error = %v", err)
+	}
+}

--- a/internal/updater/updater.go
+++ b/internal/updater/updater.go
@@ -1,8 +1,6 @@
 package updater
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"io"
@@ -107,7 +105,7 @@ func IsNewerVersion(latest, current string) bool {
 // PerformUpgrade upgrades mdp to the latest version.
 // Behavior depends on installation method:
 // - brew: prints upgrade instructions
-// - curl/unknown: downloads and replaces binary
+// - curl/PowerShell/unknown: downloads and replaces the binary
 // - source: prints upgrade instructions
 func PerformUpgrade(currentVersion string, force bool) error {
 	method := DetectInstallMethod()
@@ -118,7 +116,7 @@ func PerformUpgrade(currentVersion string, force bool) error {
 	case InstallMethodSource:
 		return handleSourceUpgrade()
 	case InstallMethodCurl, InstallMethodUnknown:
-		return handleCurlUpgrade(currentVersion, force)
+		return handleDirectUpgrade(currentVersion, force)
 	}
 
 	return nil
@@ -144,7 +142,7 @@ func handleSourceUpgrade() error {
 	return nil
 }
 
-func handleCurlUpgrade(currentVersion string, force bool) error {
+func handleDirectUpgrade(currentVersion string, force bool) error {
 	fmt.Println("Checking for updates...")
 
 	release, err := FetchLatestRelease()
@@ -161,16 +159,15 @@ func handleCurlUpgrade(currentVersion string, force bool) error {
 
 	fmt.Printf("Upgrading mdp %s → %s\n", currentVersion, latestVersion)
 
-	// Detect OS and architecture
-	osName := runtime.GOOS
-	archName := runtime.GOARCH
+	asset, err := releaseAssetFor(runtime.GOOS, runtime.GOARCH)
+	if err != nil {
+		return err
+	}
 
 	// Find matching asset
-	assetName := fmt.Sprintf("mdp-%s-%s.tar.gz", osName, archName)
-	downloadURL := release.GetAssetURL(assetName)
-
+	downloadURL := release.GetAssetURL(asset.archiveName)
 	if downloadURL == "" {
-		return fmt.Errorf("no release found for %s/%s", osName, archName)
+		return fmt.Errorf("no release found for %s/%s", runtime.GOOS, runtime.GOARCH)
 	}
 
 	// Download to temp directory
@@ -180,7 +177,7 @@ func handleCurlUpgrade(currentVersion string, force bool) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	archivePath := filepath.Join(tmpDir, assetName)
+	archivePath := filepath.Join(tmpDir, asset.archiveName)
 	fmt.Println("Downloading...")
 	if err := downloadFile(downloadURL, archivePath); err != nil {
 		return fmt.Errorf("download failed: %w", err)
@@ -188,7 +185,7 @@ func handleCurlUpgrade(currentVersion string, force bool) error {
 
 	// Extract
 	fmt.Println("Extracting...")
-	if err := extractTarGz(archivePath, tmpDir); err != nil {
+	if err := extractReleaseBinary(archivePath, tmpDir, asset); err != nil {
 		return fmt.Errorf("extraction failed: %w", err)
 	}
 
@@ -198,21 +195,21 @@ func handleCurlUpgrade(currentVersion string, force bool) error {
 		return fmt.Errorf("failed to get executable path: %w", err)
 	}
 
-	newBinary := filepath.Join(tmpDir, "mdp")
+	newBinary := filepath.Join(tmpDir, asset.binaryName)
 
-	// Replace binary
+	// Replace binary. Windows defers replacement until this process exits because
+	// a running .exe cannot be overwritten.
 	fmt.Println("Installing...")
-	if err := replaceBinary(newBinary, currentExe); err != nil {
+	deferred, err := replaceBinary(newBinary, currentExe, latestVersion)
+	if err != nil {
 		return fmt.Errorf("failed to replace binary: %w", err)
 	}
+	if deferred {
+		fmt.Printf("mdp %s downloaded; installation will complete momentarily.\n", latestVersion)
+		return nil
+	}
 
-	// Update state
-	state, _ := LoadState()
-	state.CurrentVersion = latestVersion
-	state.LatestVersion = latestVersion
-	state.LastCheckTime = time.Now()
-	_ = SaveState(state)
-
+	updateInstalledVersion(latestVersion)
 	fmt.Printf("Successfully upgraded to mdp %s\n", latestVersion)
 	return nil
 }
@@ -247,75 +244,13 @@ func downloadFile(url, destPath string) error {
 	return err
 }
 
-func extractTarGz(archivePath, destDir string) error {
-	file, err := os.Open(archivePath)
+func updateInstalledVersion(version string) {
+	state, err := LoadState()
 	if err != nil {
-		return err
+		state = &State{}
 	}
-	defer file.Close()
-
-	gzr, err := gzip.NewReader(file)
-	if err != nil {
-		return err
-	}
-	defer gzr.Close()
-
-	tr := tar.NewReader(gzr)
-
-	for {
-		header, err := tr.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return err
-		}
-
-		// Only extract the mdp binary
-		if header.Name != "mdp" {
-			continue
-		}
-
-		// Prevent path traversal
-		if strings.Contains(header.Name, "..") || filepath.IsAbs(header.Name) {
-			return fmt.Errorf("archive contains invalid path: %s", header.Name)
-		}
-
-		target := filepath.Join(destDir, filepath.Clean(header.Name))
-		outFile, err := os.OpenFile(target, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
-		if err != nil {
-			return err
-		}
-
-		_, copyErr := io.Copy(outFile, tr)
-		outFile.Close()
-		if copyErr != nil {
-			return copyErr
-		}
-	}
-
-	return nil
-}
-
-func replaceBinary(src, dst string) error {
-	// Read source file
-	srcData, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-
-	// Get destination file info for permissions
-	dstInfo, err := os.Stat(dst)
-	if err != nil {
-		return err
-	}
-
-	// On Unix, we can often rename over the running binary
-	// First try atomic rename
-	if err := os.Rename(src, dst); err == nil {
-		return nil
-	}
-
-	// Fallback: write directly (this works on most systems)
-	return os.WriteFile(dst, srcData, dstInfo.Mode())
+	state.CurrentVersion = version
+	state.LatestVersion = version
+	state.LastCheckTime = time.Now()
+	_ = SaveState(state)
 }

--- a/internal/updater/updater_test.go
+++ b/internal/updater/updater_test.go
@@ -106,6 +106,16 @@ func TestFetchLatestRelease_MockServer(t *testing.T) {
 					BrowserDownloadURL: "https://example.com/mdp-linux-amd64.tar.gz",
 					Size:               1024,
 				},
+				{
+					Name:               "mdp-windows-amd64.zip",
+					BrowserDownloadURL: "https://example.com/mdp-windows-amd64.zip",
+					Size:               1024,
+				},
+				{
+					Name:               "mdp-windows-arm64.zip",
+					BrowserDownloadURL: "https://example.com/mdp-windows-arm64.zip",
+					Size:               1024,
+				},
 			},
 		}
 		json.NewEncoder(w).Encode(release)
@@ -119,6 +129,8 @@ func TestFetchLatestRelease_MockServer(t *testing.T) {
 		Assets: []Asset{
 			{Name: "mdp-darwin-arm64.tar.gz", BrowserDownloadURL: "https://example.com/darwin-arm64"},
 			{Name: "mdp-linux-amd64.tar.gz", BrowserDownloadURL: "https://example.com/linux-amd64"},
+			{Name: "mdp-windows-amd64.zip", BrowserDownloadURL: "https://example.com/windows-amd64"},
+			{Name: "mdp-windows-arm64.zip", BrowserDownloadURL: "https://example.com/windows-arm64"},
 		},
 	}
 
@@ -129,18 +141,27 @@ func TestFetchLatestRelease_MockServer(t *testing.T) {
 		}
 	})
 
+	for _, tt := range []struct {
+		name string
+		want string
+	}{
+		{name: "mdp-windows-amd64.zip", want: "https://example.com/windows-amd64"},
+		{name: "mdp-windows-arm64.zip", want: "https://example.com/windows-arm64"},
+	} {
+		t.Run("GetAssetURL finds "+tt.name, func(t *testing.T) {
+			url := release.GetAssetURL(tt.name)
+			if url != tt.want {
+				t.Errorf("GetAssetURL() = %q, want %q", url, tt.want)
+			}
+		})
+	}
+
 	t.Run("GetAssetURL not found", func(t *testing.T) {
-		url := release.GetAssetURL("mdp-windows-amd64.zip")
+		url := release.GetAssetURL("mdp-windows-386.zip")
 		if url != "" {
 			t.Errorf("GetAssetURL() = %q, want empty string", url)
 		}
 	})
-}
-
-func TestExtractTarGz(t *testing.T) {
-	// This test would require creating actual tar.gz files
-	// Skip for now as it's an integration-level test
-	t.Skip("Integration test - requires actual tar.gz file")
 }
 
 func TestCheckForUpdateQuick_Timeout(t *testing.T) {

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,123 @@
+# install.ps1 - mdp installer for Windows
+# Usage: irm https://raw.githubusercontent.com/sadiksaifi/mdp/main/scripts/install.ps1 | iex
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+$Repository = "sadiksaifi/mdp"
+$InstallDirectory = Join-Path ([Environment]::GetFolderPath("LocalApplicationData")) "Programs\mdp"
+
+function Write-Info([string]$Message) {
+    Write-Host "==> $Message" -ForegroundColor Cyan
+}
+
+function Write-Success([string]$Message) {
+    Write-Host "==> $Message" -ForegroundColor Green
+}
+
+function Get-MdpArchitecture {
+    try {
+        $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    }
+    catch {
+        $architecture = if ($env:PROCESSOR_ARCHITEW6432) {
+            $env:PROCESSOR_ARCHITEW6432
+        }
+        else {
+            $env:PROCESSOR_ARCHITECTURE
+        }
+    }
+
+    switch ($architecture.ToUpperInvariant()) {
+        { $_ -in @("X64", "AMD64") } { return "amd64" }
+        "ARM64" { return "arm64" }
+        default { throw "Unsupported Windows architecture: $architecture. mdp supports AMD64 and ARM64." }
+    }
+}
+
+function Add-MdpToUserPath([string]$Directory) {
+    $userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $pathEntries = if ($userPath) { $userPath -split ";" } else { @() }
+    $alreadyConfigured = $pathEntries | Where-Object {
+        $_.TrimEnd("\") -ieq $Directory.TrimEnd("\")
+    }
+
+    if (-not $alreadyConfigured) {
+        $newUserPath = if ($userPath) { "$userPath;$Directory" } else { $Directory }
+        [Environment]::SetEnvironmentVariable("Path", $newUserPath, "User")
+        Write-Success "Added $Directory to your user PATH"
+    }
+
+    if (($env:Path -split ";") -notcontains $Directory) {
+        $env:Path = "$Directory;$env:Path"
+    }
+}
+
+function Install-Mdp {
+    if ([Environment]::OSVersion.Platform -ne [PlatformID]::Win32NT) {
+        throw "This installer only supports Windows."
+    }
+
+    $architecture = Get-MdpArchitecture
+    $assetName = "mdp-windows-$architecture.zip"
+
+    Write-Info "Fetching the latest mdp release..."
+    [Net.ServicePointManager]::SecurityProtocol = `
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+    $headers = @{
+        Accept = "application/vnd.github+json"
+        "User-Agent" = "mdp-installer"
+    }
+    $release = Invoke-RestMethod `
+        -Uri "https://api.github.com/repos/$Repository/releases/latest" `
+        -Headers $headers
+
+    $asset = $release.assets | Where-Object { $_.name -eq $assetName } | Select-Object -First 1
+    if (-not $asset) {
+        throw "Release asset $assetName was not found in release $($release.tag_name)."
+    }
+
+    $temporaryDirectory = Join-Path ([IO.Path]::GetTempPath()) ("mdp-install-" + [Guid]::NewGuid())
+    $archivePath = Join-Path $temporaryDirectory $assetName
+
+    try {
+        New-Item -ItemType Directory -Path $temporaryDirectory -Force | Out-Null
+
+        Write-Info "Downloading mdp $($release.tag_name) for Windows/$architecture..."
+        Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $archivePath -UseBasicParsing
+
+        Write-Info "Extracting $assetName..."
+        Expand-Archive -LiteralPath $archivePath -DestinationPath $temporaryDirectory -Force
+
+        $binaryPath = Join-Path $temporaryDirectory "mdp.exe"
+        if (-not (Test-Path -LiteralPath $binaryPath -PathType Leaf)) {
+            throw "$assetName does not contain mdp.exe."
+        }
+
+        Write-Info "Installing to $InstallDirectory..."
+        New-Item -ItemType Directory -Path $InstallDirectory -Force | Out-Null
+        Copy-Item -LiteralPath $binaryPath -Destination (Join-Path $InstallDirectory "mdp.exe") -Force
+
+        Add-MdpToUserPath $InstallDirectory
+
+        $installedBinary = Join-Path $InstallDirectory "mdp.exe"
+        $installedVersion = & $installedBinary --version
+        if ($LASTEXITCODE -ne 0) {
+            throw "Installation verification failed."
+        }
+
+        Write-Success "$installedVersion installed successfully!"
+        Write-Host ""
+        Write-Host "Get started with:"
+        Write-Host "  mdp README.md"
+        Write-Host ""
+        Write-Host "Restart your terminal if mdp is not immediately available."
+    }
+    finally {
+        if (Test-Path -LiteralPath $temporaryDirectory) {
+            Remove-Item -LiteralPath $temporaryDirectory -Recurse -Force
+        }
+    }
+}
+
+Install-Mdp

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -16,15 +16,17 @@ function Write-Success([string]$Message) {
 }
 
 function Get-MdpArchitecture {
-    try {
-        $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+    if ($env:PROCESSOR_ARCHITEW6432) {
+        # Under x64 emulation on Windows ARM64, older .NET runtimes report X64.
+        # PROCESSOR_ARCHITEW6432 identifies the native machine architecture.
+        $architecture = $env:PROCESSOR_ARCHITEW6432
     }
-    catch {
-        $architecture = if ($env:PROCESSOR_ARCHITEW6432) {
-            $env:PROCESSOR_ARCHITEW6432
+    else {
+        try {
+            $architecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
         }
-        else {
-            $env:PROCESSOR_ARCHITECTURE
+        catch {
+            $architecture = $env:PROCESSOR_ARCHITECTURE
         }
     }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -51,7 +51,7 @@ detect_os() {
             OS="linux"
             ;;
         MINGW*|MSYS*|CYGWIN*)
-            error "Windows is not supported by this installer. Please download manually from GitHub."
+            error "Use PowerShell on Windows: irm https://raw.githubusercontent.com/sadiksaifi/mdp/main/scripts/install.ps1 | iex"
             ;;
         *)
             error "Unsupported operating system: $(uname -s)"

--- a/scripts/install_test.ps1
+++ b/scripts/install_test.ps1
@@ -1,0 +1,44 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 2.0
+
+$installerPath = Join-Path $PSScriptRoot "install.ps1"
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installerPath,
+    [ref]$tokens,
+    [ref]$parseErrors
+)
+if ($parseErrors.Count -gt 0) {
+    throw "Could not parse ${installerPath}: $($parseErrors -join '; ')"
+}
+
+$architectureFunction = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+        $node.Name -eq "Get-MdpArchitecture"
+}, $true)
+if (-not $architectureFunction) {
+    throw "Get-MdpArchitecture was not found in $installerPath"
+}
+Invoke-Expression $architectureFunction.Extent.Text
+
+$originalArchitecture = $env:PROCESSOR_ARCHITECTURE
+$originalArchitectureW6432 = $env:PROCESSOR_ARCHITEW6432
+try {
+    # A PowerShell x64 process on Windows ARM64 reports AMD64 as its process
+    # architecture and ARM64 as the native machine architecture.
+    $env:PROCESSOR_ARCHITECTURE = "AMD64"
+    $env:PROCESSOR_ARCHITEW6432 = "ARM64"
+
+    $actual = Get-MdpArchitecture
+    if ($actual -ne "arm64") {
+        throw "Get-MdpArchitecture returned '$actual' under x64 emulation on ARM64; expected 'arm64'."
+    }
+}
+finally {
+    $env:PROCESSOR_ARCHITECTURE = $originalArchitecture
+    $env:PROCESSOR_ARCHITEW6432 = $originalArchitectureW6432
+}
+
+Write-Host "PowerShell installer architecture tests passed."


### PR DESCRIPTION
## Description

Add first-class Windows installation, release distribution, and self-upgrade support for AMD64 and ARM64. Windows users can install with PowerShell and subsequently upgrade with the same `mdp upgrade` command used by curl installations.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [x] Refactoring
- [ ] Other (please describe)

## Changes

- Publish `mdp-windows-amd64.zip` and `mdp-windows-arm64.zip` release archives containing `mdp.exe`.
- Add a PowerShell installer that detects the Windows architecture, installs into `%LOCALAPPDATA%\Programs\mdp`, configures the user PATH, and verifies the binary.
- Teach the updater to select and securely extract platform-specific tar.gz or ZIP archives.
- Implement deferred Windows executable replacement so `mdp upgrade` can safely replace the running binary after it exits.
- Use the system temporary directory for browser preview output on every platform.
- Add Windows distribution checks, archive extraction coverage, replacement coverage, and updated installation documentation.

## Checklist

- [x] I have tested my changes locally
- [x] I have added/updated tests if applicable
- [x] My code follows the project's style guidelines
- [x] I have updated documentation if needed

## Testing

- `go test -race ./...`
- `go vet ./...`
- Cross-compiled Windows AMD64 and ARM64 binaries.
- Parsed the CI and release workflow YAML files.

## QA

- On Windows AMD64 or ARM64, run the documented PowerShell installation command and confirm `mdp --version` works in a new terminal.
- After publishing a newer test release, run `mdp upgrade`; confirm it downloads the matching Windows ZIP, reports deferred installation, and that a subsequent `mdp --version` reports the new version.
- Preview a Markdown file and confirm the generated HTML opens from the Windows temporary directory.

## Related Issues

None.
